### PR TITLE
Don't stop running tests when there's an error with one browser.

### DIFF
--- a/brtapsauce.js
+++ b/brtapsauce.js
@@ -30,7 +30,7 @@ function brtapsauce (options, callback) {
 
     run(cap, function (err) {
       if (err)
-        return closeTests(err)
+        console.log(err);
 
       if (++i == options.capabilities.length)
         return closeTests()

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "serve-script": "~0.1.1",
-    "sauce-tap-runner": "~0.1.1",
+    "sauce-tap-runner": "~0.1.2",
     "xtend": "~2.1.2",
     "browserify": "~3.19.1"
   },


### PR DESCRIPTION
This is related to conradz/sauce-tap-runner#1.

When running tests with brtapsauce I would some times get timeout errors in old versions of IE, because of some javascript errors. When this happens, since the timeout is treated as an error rather than a failure, the tests would not run for the rest of the browsers, which I don't think is the desired behavior.

In general, I think it's a good idea to keep running the other tests for the other browsers in case of error, because the error could be related to the current browser.

Please let me know if you have any comments.